### PR TITLE
Add Dockerfile for dashboard

### DIFF
--- a/opencdx-dashboard/.dockerignore
+++ b/opencdx-dashboard/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile
+.dockerignore
+node_modules
+npm-debug.log
+README.md
+.git

--- a/opencdx-dashboard/Dockerfile
+++ b/opencdx-dashboard/Dockerfile
@@ -1,0 +1,47 @@
+FROM node:20-alpine AS base
+
+# Install dependencies only when needed
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+# Install dependencies based on the preferred package manager
+
+# Rebuild the source code only when needed
+COPY ../../ui-library /app/ui-library
+COPY ../../opencdx-gui/opencdx-dashboard /app/opencdx-gui/opencdx-dashboard
+
+WORKDIR /app/ui-library
+RUN npm install
+
+WORKDIR /app/opencdx-gui/opencdx-dashboard
+RUN npm install
+
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry during the build.
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Production image, copy all the files and run next
+FROM base AS runner
+WORKDIR /app/opencdx-gui/opencdx-dashboard
+
+ENV NODE_ENV=test
+# Uncomment the following line in case you want to disable telemetry during runtime.
+# ENV NEXT_TELEMETRY_DISABLED=1
+
+#RUN addgroup --system --gid 1001 nodejs
+#RUN adduser --system --uid 1001 nextjs
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+
+#USER nextjs
+
+EXPOSE 3005
+
+ENV PORT=3005
+
+# server.js is created by next build from the standalone output
+# https://nextjs.org/docs/pages/api-reference/next-config-js/output
+CMD npm run startDev


### PR DESCRIPTION
After building both ui-library and dashboard locally, the Dockerfile will copy the files and install the dependencies to run.

TODO, run using `next start` command instead of `next dev`