### PR TITLE
SAFECDX-3378 : Form Builder - Main ANF Statement | The Add ANF Statement pop up 'Done' button should be in disable mode with out entering a Name

### DIFF
--- a/opencdx-dashboard/src/components/auth/reset_password.tsx
+++ b/opencdx-dashboard/src/components/auth/reset_password.tsx
@@ -5,7 +5,9 @@ import '../../styles/password-validation.css';
 import styles from '../../styles/custom-input.module.css';
 import { AxiosError } from 'axios';
 import ValidationRow from '@/components/custom/validationRow';
-
+import eyeIcon from '../../../public/eye.svg';
+import crossEyeIcon from '../../../public/cross_eye.svg';
+import logo from '../../../public/login-logo.png';
 import { Card, CardBody, CardFooter, CardHeader, Image, Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, useDisclosure } from 'ui-library';
 import { toast, ToastContainer } from 'react-toastify';
 import { useRouter } from 'next/navigation';
@@ -132,7 +134,7 @@ const handleError = (error: AxiosError) => {
             alt="opencdx logos"
             aria-label="OpenCDX Logo"
             radius="none"
-            src="/login-logo.png"
+            src={logo.src}
             />
         </div>
         </CardHeader>
@@ -172,11 +174,12 @@ const handleError = (error: AxiosError) => {
                     aria-label="toggle password visibility"
                     type="button"
                     onClick={toggleVisibility}
+                    style={{ position:'absolute', right: 10, top: 15 }}
                   >
                     {isVisible ? (
-                      <img alt="nextui logo" src="/eye.svg" />
+                      <img alt="nextui logo" src={eyeIcon.src} />
                     ) : (
-                      <img alt="nextui logo" src="/cross_eye.svg" />
+                      <img alt="nextui logo" src={crossEyeIcon.src} />
                     )}
                   </button>
                 }
@@ -200,11 +203,12 @@ const handleError = (error: AxiosError) => {
                     aria-label="toggle password visibility"
                     type="button"
                     onClick={toggleConfirmVisibility}
+                    style={{ position:'absolute', right: 10, top: 15 }}
                   >
                     {isConfirmVisible ? (
-                      <img alt="nextui logo" src="/eye.svg" />
+                      <Image alt="nextui logo" src={eyeIcon.src}  />
                     ) : (
-                      <img alt="nextui logo" src="/cross_eye.svg" />
+                      <Image alt="nextui logo" src={crossEyeIcon.src}  />
                     )}
                   </button>
                 }

--- a/opencdx-dashboard/src/components/auth/signup.tsx
+++ b/opencdx-dashboard/src/components/auth/signup.tsx
@@ -20,6 +20,9 @@ import { Button, Input ,} from 'ui-library';
 import { AxiosError } from 'axios';
 import { useLocale, useTranslations } from 'next-intl';
 import Loading from '@/components/custom/loading';
+import eyeIcon from '../../../public/eye.svg';
+import crossEyeIcon from '../../../public/cross_eye.svg';
+import logo from '../../../public/login-logo.png';
 export default function SignUp() {
   const handleSuccess = (data: any) => {
     setIsLoading(false); 
@@ -126,7 +129,7 @@ const handleError = (error: AxiosError) => {
               alt="opencdx logos"
               aria-label="OpenCDX Logo"
               radius="none"
-              src="/login-logo.png"
+              src={logo.src}
             />
           </CardHeader>
 
@@ -187,11 +190,12 @@ const handleError = (error: AxiosError) => {
                     aria-label="toggle password visibility"
                     type="button"
                     onClick={toggleVisibility}
+                    style={{ position:'absolute', right: 10, top: 15 }}
                   >
                     {isVisible ? (
-                      <Image alt="nextui logo" src="/eye.svg" />
+                      <Image alt="nextui logo" src={eyeIcon.src} />
                     ) : (
-                      <Image alt="nextui logo" src="/cross_eye.svg" />
+                      <Image alt="nextui logo" src={crossEyeIcon.src} />
                     )}
                   </button>
                 }
@@ -211,11 +215,12 @@ const handleError = (error: AxiosError) => {
                     aria-label="toggle password visibility"
                     type="button"
                     onClick={toggleConfirmVisibility}
+                    style={{ position:'absolute', right: 10, top: 15 }}
                   >
                     {isConfirmVisible ? (
-                      <Image alt="nextui logo" src="/eye.svg" />
+                      <Image alt="nextui logo" src={eyeIcon.src} />
                     ) : (
-                      <Image alt="nextui logo" src="/cross_eye.svg" />
+                      <Image alt="nextui logo" src={crossEyeIcon.src} />
                     )}
                   </button>
                 }

--- a/opencdx-dashboard/src/components/custom/CustomModal.tsx
+++ b/opencdx-dashboard/src/components/custom/CustomModal.tsx
@@ -12,6 +12,7 @@ interface CustomModalProps {
   confirmText: string;
   cancelText: string;
   toastMessage: string;
+  length?: number;
 }
 
 const CustomModal: React.FC<CustomModalProps> = ({
@@ -23,6 +24,7 @@ const CustomModal: React.FC<CustomModalProps> = ({
   confirmText,
   cancelText,
   toastMessage,
+  length
 }) => {
   const handleConfirm = () => {
     onConfirm();
@@ -41,7 +43,7 @@ const CustomModal: React.FC<CustomModalProps> = ({
           <Button color="primary" variant="bordered" onPress={onClose}>
             {cancelText}
           </Button>
-          <Button color="danger" onPress={handleConfirm}>
+          <Button color={(length || 0) > 0 ? 'primary' : 'default'} onPress={handleConfirm}>
             {confirmText}
           </Button>
         </ModalFooter>

--- a/opencdx-dashboard/src/components/form-builder/edit/anf-statement/index.tsx
+++ b/opencdx-dashboard/src/components/form-builder/edit/anf-statement/index.tsx
@@ -245,6 +245,7 @@ const QuestionnaireItemWrapper: React.FC<{
         isOpen={addModal.isOpen}
         onClose={addModal.closeModal}
         title="Add ANF Statement"
+        length={anfStatementName.length}
         body={
           <>
             <p>Please name your ANF Statement</p>


### PR DESCRIPTION
Enhance authentication components with improved password visibility toggles and logo imports

- Updated reset_password.tsx and signup.tsx to use local imports for eye and cross-eye icons, and the login logo.
- Adjusted button styles for password visibility toggles for better positioning.
- Added a new optional 'length' prop to CustomModal for dynamic button styling based on the length of input.
- Integrated 'length' prop in the ANF statement modal to control button color based on the input length.