### PR TITLE
SAFECDX-3385 :[OpenCDX] Form Builder - Main ANF Statement | The Add ANF Statement pop up 'Done' button should be in disable mode with out entering a Name

### DIFF
--- a/opencdx-dashboard/src/components/custom/CustomModal.tsx
+++ b/opencdx-dashboard/src/components/custom/CustomModal.tsx
@@ -43,7 +43,7 @@ const CustomModal: React.FC<CustomModalProps> = ({
           <Button color="primary" variant="bordered" onPress={onClose}>
             {cancelText}
           </Button>
-          <Button color={(length || 0) > 0 ? 'primary' : 'default'} onPress={handleConfirm}>
+          <Button color={(length || 0) > 0 ? 'primary' : 'default'} onPress={handleConfirm} isDisabled={length === 0}>
             {confirmText}
           </Button>
         </ModalFooter>


### PR DESCRIPTION
Disable confirm button when no selection is made in CustomModal